### PR TITLE
create declaration files for all files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 build/
 .nyc_output/
 coverage/
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -3078,6 +3078,16 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -3124,7 +3134,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3148,13 +3159,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3171,19 +3184,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3314,7 +3330,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3328,6 +3345,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3344,6 +3362,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3352,13 +3371,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3379,6 +3400,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3467,7 +3489,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3481,6 +3504,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3576,7 +3600,8 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3618,6 +3643,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3639,6 +3665,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3687,13 +3714,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3772,8 +3801,7 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "growl": {
       "version": "1.10.5",
@@ -4330,6 +4358,14 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsprim": {
@@ -4990,6 +5026,7 @@
           "resolved": false,
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -5359,7 +5396,8 @@
           "version": "1.1.6",
           "resolved": false,
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -5455,6 +5493,7 @@
           "resolved": false,
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -5507,7 +5546,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -5810,7 +5850,8 @@
           "version": "1.6.1",
           "resolved": false,
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -8443,6 +8484,11 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.0",
   "description": "Orchestration For Animated Transitions",
   "source": "src/index.ts",
-  "typings": "index.d.ts",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sghall/kapellmeister.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kapellmeister",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Orchestration For Animated Transitions",
   "source": "src/index.ts",
   "typings": "index.d.ts",
@@ -56,6 +56,7 @@
     "coveralls": "^3.0.2",
     "cross-env": "^5.2.0",
     "d3-interpolate": "^1.3.2",
+    "fs-extra": "^7.0.1",
     "mocha": "^5.2.0",
     "nyc": "^13.1.0",
     "prettier": "^1.16.0",
@@ -80,12 +81,12 @@
       ".ts",
       ".tsx"
     ],
-    "include" : [
+    "include": [
       "src/**/*.ts"
     ],
     "exclude": [
       "**/*.spec.ts"
     ],
-    "all": true  
+    "all": true
   }
 }

--- a/src/BaseNode.ts
+++ b/src/BaseNode.ts
@@ -1,6 +1,6 @@
 import { now, timer, timeout } from 'd3-timer'
 import { timingDefaults, extend, getTransitionId } from './utils'
-import { Config, Transition, HashMap } from './types'
+import { Config, Transition, HashMap, Tween } from './types'
 import Events from './Events'
 
 class BaseNode {
@@ -72,7 +72,7 @@ class BaseNode {
     }
 
     Object.keys(clone).forEach(stateKey => {
-      const tweens = []
+      const tweens: Tween[] = []
       const next = clone[stateKey]
 
       if (typeof next === 'object' && Array.isArray(next) === false) {
@@ -293,7 +293,7 @@ class BaseNode {
       transition.timer.stop()
 
       delete this.transitionData[id]
-      for (const i in this.transitionData) return
+      for (const _ in this.transitionData) return
       delete this.transitionData
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export { now, Timer, timer, interval, timeout } from 'd3-timer'
 
 export type EasingFunction = (t: number) => number
 export type Interpolator = (t: number) => void
+export type Tween = () => (t: number) => void
 
 export interface Timing {
   time: number

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,18 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "declaration": false,
-    "noImplicitAny": false,
-    "noUnusedLocals": false,
+    "declaration": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
     "removeComments": true,
     "noLib": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "target": "es6",
     "sourceMap": true,
-    "allowJs": true,
+    "allowJs": false,
     "outDir": "dist",
+    "suppressImplicitAnyIndexErrors": true,
     "lib": [
       "es7"
     ]


### PR DESCRIPTION
I noticed there were no declaration files for anything outside of the `index.ts` when I upgraded `react-move` to the latest version.  I have `noImplicityAny` set and I was getting this output:

> ERROR in /Users/paulcowan/projects/meridian-new-stack/packages/d3/node_modules/kapellmeister/BaseNode.ts(2,57):
TS7016: Could not find a declaration file for module './utils'. '/Users/paulcowan/projects/meridian-new-stack/packages/d3/node_modules/kapellmeister/utils.js' implicitly has an 'any' type.
ERROR in /Users/paulcowan/projects/meridian-new-stack/packages/d3/node_modules/kapellmeister/BaseNode.ts(3,45):
TS7016: Could not find a declaration file for module './types'. '/Users/paulcowan/projects/meridian-new-stack/packages/d3/node_modules/kapellmeister/types.js' implicitly has an 'any' type.

I've changed the `tsconfig.json`' declaration setting:

`"declaration": true,`

I have also set `noImplicitAny` to true and `noUnusedLocals` to true but this might not be something you want so happy to put it back.