### PR TITLE
remove suppressImplicitAnyIndexErrors and add better typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3080,7 +3080,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3104,13 +3105,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3127,19 +3130,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3270,7 +3276,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3284,6 +3291,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3300,6 +3308,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3308,13 +3317,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3335,6 +3346,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3423,7 +3435,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3437,6 +3450,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3532,7 +3546,8 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3574,6 +3589,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3595,6 +3611,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3643,13 +3660,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7850,9 +7869,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "source-map-support": "^0.5.10",
     "ts-node": "^8.0.2",
     "tslint": "^5.13.1",
-    "typescript": "^2.9.2",
+    "typescript": "^3.3.3333",
     "webpack": "^4.29.6"
   },
   "nyc": {

--- a/src/BaseNode.spec.ts
+++ b/src/BaseNode.spec.ts
@@ -1,11 +1,13 @@
 /* eslint-env mocha */
-const sinon = require('sinon')
 import { assert } from 'chai'
 import BaseNode from './BaseNode'
 
-const interpolateNumber = function(a: number, b: number) {
-  return a = +a, b -= a, function(t: number) {
-    return a + b * t;
+// tslint:disable:no-var-requires
+const sinon = require('sinon')
+
+const interpolateNumber = (a: number, b: number) => {
+  return a = +a, b -= a, (t: number) => {
+    return a + b * t
   }
 }
 
@@ -80,8 +82,10 @@ describe('<class BaseNode>', () => {
       x: [1],
       y: [1],
       events: {
-        start: spy
-      }
+        start: spy,
+        interrupt: () => {},
+        end: () => {}
+      },
     })
 
     setTimeout(() => {
@@ -101,7 +105,8 @@ describe('<class BaseNode>', () => {
       y: [1],
       events: {
         start: startSpy,
-        interrupt: interruptSpy
+        interrupt: interruptSpy,
+        end: () => {}
       }
     })
 
@@ -123,7 +128,8 @@ describe('<class BaseNode>', () => {
       y: [1],
       events: {
         start: startSpy,
-        interrupt: interruptSpy
+        interrupt: interruptSpy,
+        end: () => {}
       }
     })
 
@@ -133,7 +139,8 @@ describe('<class BaseNode>', () => {
         y: [2],
         events: {
           start: startSpy,
-          interrupt: interruptSpy
+          interrupt: interruptSpy,
+          end: () => {}
         }
       })
     }, 100)
@@ -226,13 +233,14 @@ describe('<class BaseNode>', () => {
   })
 
   it('should send correct attr and namespace to getInterpolator', done => {
-    let sentX = false 
-    let sentY = false 
+    let sentX = false
+    let sentY = false
 
     let sentNsX = false
     let sentNsY = false
 
-    class Node extends BaseNode {
+    // tslint:disable:max-classes-per-file
+    class NamespaceNode extends BaseNode {
       getInterpolator(a: number, b: number, attr: string, namespace: string) {
         if (attr === 'x' && namespace === null) {
           sentX = true
@@ -254,8 +262,8 @@ describe('<class BaseNode>', () => {
       }
     }
 
-    const node = new Node()
-    
+    const node = new NamespaceNode()
+
     node.setState({
       x: 1,
       y: 2,

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -1,10 +1,16 @@
 import { once } from './utils'
 import { Config } from './types'
 
-export class Events {
+export interface Eventable {
+  [key: string]: () => void
+}
+
+export class Events implements Eventable {
   start: () => void
   interrupt: () => void
   end: () => void
+
+  [key: string]: () => void
 
   constructor(config: Config) {
     this.start = null

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -3,10 +3,13 @@ import { Config } from './types'
 
 export interface Eventable {
   [key: string]: () => void
+  start: () => void
+  interrupt: () => void
+  end: () => void
 }
 
 export class Events implements Eventable {
-  start: () => void
+  start: (() => void) | null
   interrupt: () => void
   end: () => void
 

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -9,7 +9,7 @@ export interface Eventable {
 }
 
 export class Events implements Eventable {
-  start: (() => void) | null
+  start: () => void
   interrupt: () => void
   end: () => void
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { Timer } from 'd3-timer'
-import Events from './Events'
+import Events, { Eventable } from './Events'
 
 export interface HashMap {
   [key: string]: any
@@ -30,25 +30,26 @@ export interface Transition {
 
 export type CustomInterpolator = (t: number) => any
 
+export type NameSpaceType = number[]
+  | string[]
+  | number
+  | string
+  | CustomInterpolator
+
 export interface NameSpace {
-  [key: string]:
-    | Array<number>
-    | Array<string>
-    | number
-    | string
-    | CustomInterpolator
+  [key: string]: NameSpaceType
 }
 
 export interface Config {
   [key: string]:
-    | Array<number>
-    | Array<string>
+    | number[]
+    | string[]
     | number
     | string
     | CustomInterpolator
     | NameSpace
     | Timing
-  events  ?: Events
+  events?: Eventable
 }
 
 export interface Indexable {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export { now, Timer, timer, interval, timeout } from 'd3-timer'
 
 export type EasingFunction = (t: number) => number
 export type Interpolator = (t: number) => void
-export type Tween = () => (t: number) => void
+export type Tween = () => ((t: number) => void) | null
 
 export interface Timing {
   time: number
@@ -47,6 +47,10 @@ export interface Config {
     | string
     | CustomInterpolator
     | NameSpace
-    | Events
     | Timing
+  events  ?: Events
+}
+
+export interface Indexable {
+  [key: string]: any
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { EasingFunction, Indexable } from './types'
+import { EasingFunction, Indexable, Config, NameSpace } from './types'
 
 let transitionId = 0
 
@@ -21,6 +21,10 @@ export function once(func: () => void): () => void {
       func.call(this)
     }
   }
+}
+
+export function isNamespace<K extends keyof Config>(prop: Config[K]): prop is NameSpace {
+  return typeof prop === 'object' && Array.isArray(prop) === false
 }
 
 const linear: EasingFunction = (t: number) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { EasingFunction } from './types'
+import { EasingFunction, Indexable } from './types'
 
 let transitionId = 0
 
@@ -6,7 +6,7 @@ export function getTransitionId() {
   return ++transitionId
 }
 
-export function extend(obj: object, props: object) {
+export function extend(obj: Indexable, props: Indexable) {
   for (const i in props) {
     obj[i] = props[i]
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "sourceMap": true,
     "allowJs": false,
     "outDir": "dist",
-    "suppressImplicitAnyIndexErrors": true,
     "lib": [
       "es7"
     ]


### PR DESCRIPTION
If this is annoying then please ignore but....

I've had a go at improving the typing.  Removed the `suppressImplicitAnyIndexErrors` as you are making heavy use of indexing, it makes sense to have better typing around it. I added this so I think I should remove it :).

I've changed no code, jus the typing.

1 thing I could not type was line 87 in `BaseNode`:

```
      if (typeof next === 'object' && Array.isArray(next) === false) {
        Object.keys(next).forEach(attr => {
          // TODO: could not quite understand what next is here
          const val = (next as any)[attr]
```

I could not quite work out what it is supposed to be.

Please don't feel obliged to accept this PR, I'm just trying to suppress the errors I am seeing in my console.